### PR TITLE
Support for darwin/arm Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ build:
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_darwin_arm
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm

--- a/internal/provider/data_source_metric_data.go
+++ b/internal/provider/data_source_metric_data.go
@@ -242,7 +242,7 @@ func (d *MetricDataDataSource) Read(ctx context.Context, req datasource.ReadRequ
         data.IsMonotonic = types.BoolValue(val)
     }
     if val, ok := metricDataResponse["count"].(float64); ok {
-        data.Count = types.NumberValue(big.NewFloat(val))
+        data.CountValue = types.NumberValue(big.NewFloat(val))
     }
     if val, ok := metricDataResponse["sum"].(float64); ok {
         data.Sum = types.NumberValue(big.NewFloat(val))


### PR DESCRIPTION
Hey all, was trying to use this provider on a darwin/arm machine, but it looks like there is no release for it.

I added it to the `Makefile` here and was able to use it.

Additionally, I found that trying to build off `master` had an error trying to reference a missing attribute of `MetricDataDataSource`, so fixed that as well so the build would work.